### PR TITLE
Upgrade celluloid gem to avoid a dependency issue

### DIFF
--- a/lib/woodhouse/process.rb
+++ b/lib/woodhouse/process.rb
@@ -28,7 +28,7 @@ class Woodhouse::Process
     Woodhouse::Watchdog.start
 
     begin
-      @server.start!
+      @server.async.start
       puts "Woodhouse serving as of #{Time.now}. Ctrl-C to stop."
       @server.wait(:shutdown) 
     rescue Interrupt
@@ -41,7 +41,7 @@ class Woodhouse::Process
 
   def shutdown
     puts "Shutting down."
-    @server.shutdown!
+    @server.async.shutdown
     @server.wait(:shutdown)
   end
 

--- a/lib/woodhouse/scheduler.rb
+++ b/lib/woodhouse/scheduler.rb
@@ -52,7 +52,7 @@ class Woodhouse::Scheduler
         @config.logger.debug "Spinning up thread #{idx} for worker #{@worker_def.describe}"
         worker = @config.runner_type.new_link(@worker_def, @config)
         @threads << worker
-        worker.subscribe!
+        worker.async.subscribe
       end
     end
 

--- a/woodhouse.gemspec
+++ b/woodhouse.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "woodhouse"
 
-  s.add_dependency 'celluloid', '~> 0.12.4'
+  s.add_dependency 'celluloid', '~> 0.15'
   s.add_dependency 'bunny', "~> 0.9.0.pre4"
   s.add_dependency 'connection_pool'
   s.add_dependency 'json'


### PR DESCRIPTION
In the old version, celluloid didn’t lock the timers gem down to a major
  version (it used >=), so the most recent version with a different API 
  was fetched instead.

As far as I can tell, the only thing that changed is the way celluloid
  handles making a method asynchronous.  I’m not sure if woodhouse was following
  a similar async naming convention (! indicates async) and if so, whether
  changes are desired to bring the woodhouse api into the new convention.

I tested this locally by setting up our apps to run against both the file runner and RabbitMQ and things seemed to be working.
