### PR TITLE
fix version string

### DIFF
--- a/lib/woodhouse/version.rb
+++ b/lib/woodhouse/version.rb
@@ -1,3 +1,3 @@
 module Woodhouse
-  VERSION = "2.0.0-alpha1"
+  VERSION = "2.0.0pre1"
 end


### PR DESCRIPTION
Bundler complains about the version format.

`Updating git://github.com/mboeh/woodhouse.git There was a ArgumentError while loading woodhouse.gemspec: Malformed version number string 2.0.0-alpha1 from /opt/boxen/rbenv/versions/2.0.0-p451/lib/ruby/gems/2.0.0/bundler/gems/woodhouse-f875fa03ba1c/woodhouse.gemspec:7:in `block in <main>'`
